### PR TITLE
clack upgrade + create/delete fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,15 +15,14 @@
     "type": "module",
     "license": "ISC",
     "dependencies": {
-        "@clack/prompts": "^0.11.0",
+        "@clack/prompts": "^1.0.0-alpha.8",
         "@ts-stack/markdown": "^1.5.0",
+        "airtable": "^0.12.2",
         "ascii-table3": "^1.0.1",
-        "clack": "^0.1.0",
         "figlet": "^1.9.4",
         "picocolors": "^1.1.1",
         "uuid": "^13.0.0",
-        "webflow-api": "^3.2.1",
-        "airtable": "^0.12.2"
+        "webflow-api": "^3.2.1"
     },
     "devDependencies": {
         "@types/bun": "^1.3.4",

--- a/src/cli/flows/main-menu/manage-syncs/manage-sync/index.ts
+++ b/src/cli/flows/main-menu/manage-syncs/manage-sync/index.ts
@@ -1,9 +1,8 @@
 // import { AsciiTable3 } from 'ascii-table3'
 import { manageSyncs } from '..'
 import { tinySync } from '../../../../../core'
-import { createSyncEmitter } from '../../../../../core/sync/emitter'
 import type { Sync } from '../../../../../core/types'
-import { ui } from '../../../../ui'
+import { createClackProgressEmitter, ui } from '../../../../ui'
 import { deleteSync } from './delete-sync'
 import { validateSyncTokens } from './validate-sync-tokens'
 import { viewSyncDetails } from './view-sync-details'
@@ -40,32 +39,14 @@ export async function manageSync(sync: Sync) {
 
         switch (userChoice) {
             case 'runSync':
-                const emitter = createSyncEmitter()
-
-                emitter.on('progress', ({ step, message }) => {
-                    ui.prompt.log.info(`[${step}] ${message}`)
-                })
-
-                emitter.on('error', ({ step, error, fatal }) => {
-                    ui.prompt.log.error(
-                        `[${step}] ${fatal ? 'FATAL' : 'Warning'}: ${error.message}`
-                    )
-                })
-
-                emitter.on('complete', ({ timeElapsed, summary }) => {
-                    ui.prompt.log.success(
-                        `✅ Sync completed in ${timeElapsed}s`
-                    )
-                    ui.prompt.log.success(
-                        `   Created: ${summary.created}, Updated: ${summary.updated}, Deleted: ${summary.deleted}, Failed: ${summary.failed}`
-                    )
-                })
+                const clack = createClackProgressEmitter()
+                clack.start()
 
                 await tinySync.sync(
                     sync,
                     tokens.airtable,
                     tokens.webflow,
-                    emitter
+                    clack.emitter
                 )
                 return await manageSync(sync)
             case 'viewDetails':

--- a/src/cli/ui/create-clack-progress-emitter.ts
+++ b/src/cli/ui/create-clack-progress-emitter.ts
@@ -1,0 +1,74 @@
+import * as p from '@clack/prompts'
+import { createSyncEmitter, type SyncEmitter } from '../../core/sync/emitter'
+
+/** Clack progress bar type from @clack/prompts */
+type ClackProgress = ReturnType<typeof p.progress>
+
+/** Combined emitter with clack progress bar controls */
+export interface ClackProgressEmitter {
+    /** The underlying SyncEmitter - pass this to runSync() */
+    emitter: SyncEmitter
+    /** Direct access to the clack progress bar */
+    progress: ClackProgress
+    /** Start the progress bar - call before runSync() */
+    start: () => void
+    /** Manually stop the progress bar (auto-called on complete/fatal error) */
+    stop: (message?: string) => void
+}
+
+/**
+ * Creates a SyncEmitter that integrates with @clack/prompts progress bar.
+ * The emitter auto-advances and updates the progress bar on events.
+ *
+ * @param options - Configuration for the clack progress bar
+ * @param options.max - Maximum value for the progress bar (total steps)
+ * @param options.size - Width of the progress bar in characters
+ * @param options.style - Style of the progress bar: 'light', 'heavy', 'block'
+ *
+ * @example
+ * ```ts
+ * const clack = createClackProgressEmitter({ max: 10 })
+ * clack.start()
+ * await runSync(sync, airtableToken, webflowToken, clack.emitter)
+ * // Progress bar auto-stops on complete or fatal error
+ * ```
+ */
+export function createClackProgressEmitter(options?: {
+    max?: number
+    size?: number
+    style?: 'light' | 'heavy' | 'block'
+}): ClackProgressEmitter {
+    const emitter = createSyncEmitter()
+    const progressBar = p.progress({
+        max: options?.max ?? 10,
+        size: options?.size ?? 10,
+        style: options?.style ?? 'heavy',
+    })
+
+    // Wire up the emitter events to the clack progress bar
+    emitter.on('progress', ({ message, data }) => {
+        if (data?.noProgress) return
+        progressBar.message(message)
+        progressBar.advance(data?.advance ? data?.advance : 1)
+    })
+
+    emitter.on('error', ({ error, fatal }) => {
+        if (fatal) {
+            progressBar.stop(`Error: ${error.message}`)
+        }
+    })
+
+    emitter.on('complete', ({ timeElapsed, summary }) => {
+        const { created, updated, deleted, failed } = summary
+        progressBar.stop(
+            `Sync completed in ${timeElapsed.toFixed(1)}s — Created: ${created}, Updated: ${updated}, Deleted: ${deleted}${failed > 0 ? `, Failed: ${failed}` : ''}`
+        )
+    })
+
+    return {
+        emitter,
+        progress: progressBar,
+        start: () => progressBar.start(),
+        stop: (message?: string) => progressBar.stop(message),
+    }
+}

--- a/src/cli/ui/index.ts
+++ b/src/cli/ui/index.ts
@@ -1,7 +1,10 @@
 import * as p from '@clack/prompts'
+
 import f from 'picocolors'
 import { welcomeMessage } from './welcome-message'
 import { handleCancel } from './handle-cancel'
+
+export { createClackProgressEmitter } from './create-clack-progress-emitter'
 
 // Update the UI interface to include the additional spinner methods
 interface UI {

--- a/src/core/sync/create-items.ts
+++ b/src/core/sync/create-items.ts
@@ -7,6 +7,7 @@ import type { SyncEmit } from './emitter'
 
 export interface CreatedItem extends ParsedRecord {
     itemId: string
+    slug: string
 }
 
 const batchSize = 100
@@ -24,10 +25,7 @@ export async function createItems(
     const numberOfItems = createWebflowItems.length
     if (numberOfItems === 0) return { createdItems, failedCreateRecords }
 
-    emit.progress(
-        'create',
-        `Creating ${createWebflowItems.length} items in Webflow...`
-    )
+    emit.progress(`Creating ${createWebflowItems.length} Webflow items`)
 
     const { recordsWithParsingErrors, parsedRecords } = parseAirtableRecords(
         createWebflowItems,
@@ -91,9 +89,9 @@ export async function createItems(
     }
 
     emit.progress(
-        'create',
         `Created ${createdItems.length} items, ${failedCreateRecords.length} failed`,
         {
+            noProgress: true,
             created: createdItems.length,
             failed: failedCreateRecords.length,
         }
@@ -101,7 +99,6 @@ export async function createItems(
 
     if (failedCreateRecords.length > 0) {
         emit.error(
-            'create',
             new Error(`Failed to create ${failedCreateRecords.length} items`),
             false
         )
@@ -178,6 +175,7 @@ function matchResponseToRecord(
             return {
                 ...record,
                 itemId: item.id,
+                slug: item.fieldData.slug,
             }
         })
         .filter((item): item is CreatedItem => item !== null)

--- a/src/core/sync/delete-items.ts
+++ b/src/core/sync/delete-items.ts
@@ -35,8 +35,7 @@ export async function deleteItems(
         return { deletedItems, deletedOrphanedItems, failedDeleteRecords }
 
     emit.progress(
-        'delete',
-        `Deleting ${numberOfOrphanedItems + numberOfItems} items from Webflow...`
+        `Deleting ${numberOfOrphanedItems + numberOfItems} Weblofw items`
     )
 
     // Get the itemId field to extract existing Webflow item IDs
@@ -195,9 +194,9 @@ export async function deleteItems(
     }
 
     emit.progress(
-        'delete',
         `Deleted ${deletedItems.length} items, ${failedDeleteRecords.length} failed`,
         {
+            noProgress: true,
             deleted: deletedItems.length,
             failed: failedDeleteRecords.length,
         }
@@ -205,7 +204,6 @@ export async function deleteItems(
 
     if (failedDeleteRecords.length > 0) {
         emit.error(
-            'delete',
             new Error(`Failed to delete ${failedDeleteRecords.length} items`),
             false
         )
@@ -221,7 +219,19 @@ async function deleteItemBatch(
 ) {
     await webflowClient.collections.items.deleteItemsLive(
         sync.config.webflow.collection.id,
-        { items: itemIds as unknown as ItemsDeleteItemsLiveRequestItemsItem[] }
+        {
+            items: itemIds.map((id) => ({
+                id,
+            })) as unknown as ItemsDeleteItemsLiveRequestItemsItem[],
+        }
+    )
+    await webflowClient.collections.items.deleteItems(
+        sync.config.webflow.collection.id,
+        {
+            items: itemIds.map((id) => ({
+                id,
+            })) as unknown as ItemsDeleteItemsLiveRequestItemsItem[],
+        }
     )
 }
 

--- a/src/core/sync/emitter.ts
+++ b/src/core/sync/emitter.ts
@@ -7,14 +7,18 @@ export function createSyncEmitter(): SyncEmitter {
 
 export type SyncEventType = 'progress' | 'error' | 'complete'
 
+export type SyncProgressEventData = {
+    advance?: number
+    noProgress?: boolean
+    [key: string]: any
+}
+
 export interface SyncProgressEvent {
-    step: string
     message: string
-    data?: any
+    data?: SyncProgressEventData
 }
 
 export interface SyncErrorEvent {
-    step: string
     error: Error
     fatal: boolean
 }
@@ -39,8 +43,8 @@ export interface SyncEmitter extends EventEmitter {
 }
 
 export interface SyncEmit {
-    progress: (step: string, message: string, data?: any) => void
-    error: (step: string, error: Error, fatal: boolean) => void
+    progress: (message: string, data?: SyncProgressEventData) => void
+    error: (error: Error, fatal: boolean) => void
     complete: (
         timeElapsed: number,
         summary: SyncCompleteEvent['summary']

--- a/src/core/sync/parse-actions/index.ts
+++ b/src/core/sync/parse-actions/index.ts
@@ -11,7 +11,7 @@ export async function parseActions(
     webflowItems: CollectionItemList,
     emit: SyncEmit
 ): Promise<SyncActions> {
-    emit.progress('Parse', 'Parsing actions...')
+    emit.progress('Parsing actions...')
     if (!webflowItems.items) throw new Error('Webflow items not found')
 
     const { itemIdFieldId, stateFieldId } = getSpecialFieldIds(sync)
@@ -52,7 +52,7 @@ export async function parseActions(
             case 'error':
                 recordsWithErrors.push({
                     record,
-                    errors: [action.message],
+                    errors: ['parse-action:', action.message],
                 })
                 break
             case 'skip':
@@ -68,16 +68,13 @@ export async function parseActions(
         orphanedItems.push(...filteredItems)
     }
 
-    emit.progress(
-        'Parse',
-        `Parsed actions: ${createWebflowItem.length} to create, ${updateWebflowItem.length} to update, ${deleteWebflowItem.length} to delete`,
-        {
-            create: createWebflowItem.length,
-            update: updateWebflowItem.length,
-            delete: deleteWebflowItem.length,
-            orphaned: orphanedItems.length,
-        }
-    )
+    emit.progress(`Parsed actions`, {
+        noProgress: true,
+        create: createWebflowItem.length,
+        update: updateWebflowItem.length,
+        delete: deleteWebflowItem.length,
+        orphaned: orphanedItems.length,
+    })
 
     return {
         createWebflowItem,

--- a/src/core/sync/update-items.ts
+++ b/src/core/sync/update-items.ts
@@ -8,6 +8,7 @@ import type { SyncEmit } from './emitter'
 
 export interface UpdatedItem extends ParsedRecord {
     itemId: string
+    slug: string
 }
 
 const batchSize = 100
@@ -25,10 +26,7 @@ export async function updateItems(
     const numberOfItems = updateWebflowItems.length
     if (numberOfItems === 0) return { updatedItems, failedUpdateRecords }
 
-    emit.progress(
-        'update',
-        `Updating ${updateWebflowItems.length} items in Webflow...`
-    )
+    emit.progress(`Updating ${updateWebflowItems.length} Webflow items`)
 
     // Get the itemId field to extract existing Webflow item IDs
     const itemIdField = findSpecialField('itemId', sync)
@@ -123,9 +121,9 @@ export async function updateItems(
     }
 
     emit.progress(
-        'update',
         `Updated ${updatedItems.length} items, ${failedUpdateRecords.length} failed`,
         {
+            noProgress: true,
             updated: updatedItems.length,
             failed: failedUpdateRecords.length,
         }
@@ -133,7 +131,6 @@ export async function updateItems(
 
     if (failedUpdateRecords.length > 0) {
         emit.error(
-            'update',
             new Error(`Failed to update ${failedUpdateRecords.length} items`),
             false
         )
@@ -210,6 +207,7 @@ function matchResponseToRecord(
             return {
                 ...record,
                 itemId: item.id,
+                slug: item.fieldData.slug,
             }
         })
         .filter((item): item is UpdatedItem => item !== null)

--- a/src/core/sync/update-records.ts
+++ b/src/core/sync/update-records.ts
@@ -15,120 +15,116 @@ export async function updateRecords(
     airtableToken: string,
     emit: SyncEmit
 ) {
-    emit.progress(
-        'updateRecords',
-        'Updating Airtable records with sync results...'
-    )
+    try {
+        emit.progress('Updating Airtable records')
 
-    const specialFields = findAllSpecialFields(sync)
-    /* ------------------------------ create items ------------------------------ */
-    for (const createdItem of createdItems) {
-        let stateValue = 'Staging'
-        switch (
-            createdItem.record.fields[specialFields.stateField.airtable.id]
-        ) {
-            case 'Always sync':
-                stateValue = 'Always sync'
-                break
-            case 'Queued for sync':
-                stateValue = 'Staging'
-                break
-        }
-        const payload = {
-            [specialFields.itemIdField.airtable.id]: createdItem.itemId,
-            [specialFields.lastPublishedField.airtable.id]:
-                new Date().toISOString(),
-            [specialFields.slugField.airtable.id]:
-                createdItem.collectionItem.fieldData.slug,
-            [specialFields.stateField.airtable.id]: stateValue,
-            [specialFields.errorsField.airtable.id]: '',
-        }
+        const specialFields = findAllSpecialFields(sync)
+        /* ------------------------------ create items ------------------------------ */
+        for (const createdItem of createdItems) {
+            let stateValue = 'Staging'
+            switch (
+                createdItem.record.fields[specialFields.stateField.airtable.id]
+            ) {
+                case 'Always sync':
+                    stateValue = 'Always sync'
+                    break
+                case 'Queued for sync':
+                    stateValue = 'Staging'
+                    break
+            }
+            const payload = {
+                [specialFields.itemIdField.airtable.id]: createdItem.itemId,
+                [specialFields.lastPublishedField.airtable.id]:
+                    new Date().toISOString(),
+                [specialFields.slugField.airtable.id]: createdItem.slug,
+                [specialFields.stateField.airtable.id]: stateValue,
+                [specialFields.errorsField.airtable.id]: '',
+            }
 
-        const response = await airtable.update.record(
-            airtableToken,
-            sync.config.airtable.base.id,
-            sync.config.airtable.table.id,
-            createdItem.record.id,
-            payload
-        )
-
-        if (response.error)
-            console.error('Error updating record:', response.error)
-    }
-
-    /* ----------------------------- update records ----------------------------- */
-    for (const createdItem of updatedItems) {
-        let stateValue = 'Staging'
-        switch (
-            createdItem.record.fields[specialFields.stateField.airtable.id]
-        ) {
-            case 'Always sync':
-                stateValue = 'Always sync'
-                break
-            case 'Queued for sync':
-                stateValue = 'Staging'
-                break
-        }
-        const payload = {
-            [specialFields.lastPublishedField.airtable.id]:
-                new Date().toISOString(),
-            [specialFields.slugField.airtable.id]:
-                createdItem.collectionItem.fieldData.slug,
-            [specialFields.stateField.airtable.id]: stateValue,
-            [specialFields.errorsField.airtable.id]: '',
-        }
-
-        const response = await airtable.update.record(
-            airtableToken,
-            sync.config.airtable.base.id,
-            sync.config.airtable.table.id,
-            createdItem.record.id,
-            payload
-        )
-
-        if (response.error)
-            console.error('Error updating record:', response.error)
-    }
-
-    /* ----------------------------- delete records ----------------------------- */
-    for (const deletedItem of deletedItems) {
-        const payload = {
-            [specialFields.lastPublishedField.airtable.id]: '',
-            [specialFields.slugField.airtable.id]: '',
-            [specialFields.itemIdField.airtable.id]: '',
-            [specialFields.errorsField.airtable.id]: '',
-        }
-
-        const response = await airtable.update.record(
-            airtableToken,
-            sync.config.airtable.base.id,
-            sync.config.airtable.table.id,
-            deletedItem.record.id,
-            payload
-        )
-
-        if (response.error)
-            console.error('Error updating record:', response.error)
-    }
-
-    /* ----------------------------- failed records ----------------------------- */
-    for (const failedRecord of failedRecords) {
-        //convert error array to CSV string
-        const errorsAsString = failedRecord.errors.join(', ')
-        const payload = {
-            [specialFields.errorsField.airtable.id]: errorsAsString,
-        }
-
-        try {
-            await airtable.update.record(
+            const response = await airtable.update.record(
                 airtableToken,
                 sync.config.airtable.base.id,
                 sync.config.airtable.table.id,
-                failedRecord.record.id,
+                createdItem.record.id,
                 payload
             )
-        } catch (error) {
-            console.error('Error updating record:', error)
+
+            if (response.error) throw new Error(response.error)
         }
+
+        /* ----------------------------- update records ----------------------------- */
+        for (const updatedItem of updatedItems) {
+            let stateValue = 'Staging'
+            switch (
+                updatedItem.record.fields[specialFields.stateField.airtable.id]
+            ) {
+                case 'Always sync':
+                    stateValue = 'Always sync'
+                    break
+                case 'Queued for sync':
+                    stateValue = 'Staging'
+                    break
+            }
+            const payload = {
+                [specialFields.lastPublishedField.airtable.id]:
+                    new Date().toISOString(),
+                [specialFields.slugField.airtable.id]: updatedItem.slug,
+                [specialFields.stateField.airtable.id]: stateValue,
+                [specialFields.errorsField.airtable.id]: '',
+            }
+
+            const response = await airtable.update.record(
+                airtableToken,
+                sync.config.airtable.base.id,
+                sync.config.airtable.table.id,
+                updatedItem.record.id,
+                payload
+            )
+
+            if (response.error) throw new Error(response.error)
+        }
+
+        /* ----------------------------- delete records ----------------------------- */
+        for (const deletedItem of deletedItems) {
+            const payload = {
+                [specialFields.lastPublishedField.airtable.id]: '',
+                [specialFields.slugField.airtable.id]: '',
+                [specialFields.itemIdField.airtable.id]: '',
+                [specialFields.errorsField.airtable.id]: '',
+            }
+
+            const response = await airtable.update.record(
+                airtableToken,
+                sync.config.airtable.base.id,
+                sync.config.airtable.table.id,
+                deletedItem.record.id,
+                payload
+            )
+
+            if (response.error) throw new Error(response.error)
+        }
+
+        /* ----------------------------- failed records ----------------------------- */
+        for (const failedRecord of failedRecords) {
+            //convert error array to CSV string
+            const errorsAsString = failedRecord.errors.join(', ')
+            const payload = {
+                [specialFields.errorsField.airtable.id]: errorsAsString,
+            }
+
+            try {
+                await airtable.update.record(
+                    airtableToken,
+                    sync.config.airtable.base.id,
+                    sync.config.airtable.table.id,
+                    failedRecord.record.id,
+                    payload
+                )
+            } catch (error) {
+                throw error
+            }
+        }
+    } catch (error) {
+        emit.error(new Error(`Failed to update Airtable records`), false)
     }
 }


### PR DESCRIPTION
Using alpha version of clack
Implement clack progress bar for CLI
Fixed create bug where generated slug return from WF was not written back to AT record causing issues Fixed bug where items were failing deletion due to data structure. Fixed bug where items were only being unpublished rather than unpublished then deleted