### PR TITLE
Centralize and update CLI data directory handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 **/data
 **/logs
 **/dev
+**/dist

--- a/packages/cli/build.ts
+++ b/packages/cli/build.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+/**
+ * Build script for @tinysync/cli
+ *
+ * Creates a bundled executable using Bun's bundler.
+ * The output can be run with `bun dist/cli.js` or compiled to a binary.
+ */
+
+import { $ } from 'bun'
+
+const startTime = performance.now()
+
+console.log('🔨 Building @tinysync/cli...\n')
+
+// Clean the dist directory
+await $`rm -rf dist`
+
+// Bundle the CLI
+const result = await Bun.build({
+    entrypoints: ['./src/index.ts'],
+    outdir: './dist',
+    target: 'bun', // Target Bun runtime
+    minify: false, // Keep readable for debugging; set to true for production
+    sourcemap: 'external', // Generate sourcemaps for debugging
+    external: [
+        // figlet loads font files dynamically at runtime, so it can't be bundled
+        'figlet',
+    ],
+    define: {
+        'process.env.NODE_ENV': JSON.stringify('production'),
+    },
+})
+
+if (!result.success) {
+    console.error('❌ Build failed:')
+    for (const log of result.logs) {
+        console.error(log)
+    }
+    process.exit(1)
+}
+
+// Report build outputs
+console.log('📦 Build outputs:')
+for (const output of result.outputs) {
+    const sizeKB = (output.size / 1024).toFixed(2)
+    console.log(`   ${output.path} (${sizeKB} KB)`)
+}
+
+const endTime = performance.now()
+console.log(`\n✅ Build completed in ${(endTime - startTime).toFixed(0)}ms`)
+
+console.log('\n💡 To run the bundled CLI:')
+console.log('   bun dist/index.js')
+
+console.log('\n💡 To compile to a standalone binary:')
+console.log('   bun build --compile dist/index.js --outfile tinysync')

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,13 @@
 {
     "name": "@tinysync/cli",
-    "version": "1.0.1",
+    "version": "1.0.3",
     "description": "CLI tool for tinysync - sync data between Airtable and Webflow",
-    "main": "./src/index.ts",
+    "main": "./dist/index.js",
     "bin": {
-        "tinysync": "./src/index.ts"
+        "tinysync": "./dist/index.js"
     },
     "files": [
-        "src",
-        "data",
+        "dist",
         "README.md",
         "LICENSE.txt"
     ],
@@ -16,6 +15,7 @@
         "start": "bun src/index.ts",
         "__start:local_warning": "SECURITY: Disables TLS verification. Only use for corporate VPN cert issues during local dev.",
         "start:local": "export NODE_TLS_REJECT_UNAUTHORIZED=0 && bun src/index.ts",
+        "build": "bun build.ts",
         "test": "bun test"
     },
     "keywords": [

--- a/packages/cli/src/flows/main-menu/manage-syncs/manage-sync/save-verbose-logs.ts
+++ b/packages/cli/src/flows/main-menu/manage-syncs/manage-sync/save-verbose-logs.ts
@@ -2,9 +2,7 @@ import { type Sync, type SyncVerboseLogs } from '@tinysync/core'
 import { join } from 'path'
 import { ui } from '../../../../ui'
 import { writeToJSONFile } from '../../../../utils/write-to-json-file'
-
-/** Directory for storing verbose sync logs */
-const logsDir = join(import.meta.dir, '../../../../../logs/')
+import { logsDir } from '../../../../utils/paths'
 
 /** Save verbose logs to JSON files */
 export async function saveVerboseLogs(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,8 +9,12 @@ import pack from '../package.json'
 import { ui } from './ui'
 import { login } from './flows/login'
 import { mainMenu } from './flows/main-menu'
+import { ensureDataDirs } from './utils/paths'
 ;(async () => {
     try {
+        // Ensure data directories exist before any file operations
+        ensureDataDirs()
+
         await ui.welcome()
 
         ui.prompt.intro(ui.format.dim(`tinysync CLI v${pack.version}`))
@@ -22,6 +26,11 @@ import { mainMenu } from './flows/main-menu'
         ui.prompt.outro(`See ya later! 👋`)
     } catch (error) {
         ui.prompt.log.error('There was an error running tinysync CLI.')
-        ui.prompt.log.error(error as string)
+        ui.prompt.log.error(
+            error instanceof Error ? error.message : String(error)
+        )
+        if (error instanceof Error && error.stack) {
+            console.error(error.stack)
+        }
     }
 })()

--- a/packages/cli/src/syncs/index.ts
+++ b/packages/cli/src/syncs/index.ts
@@ -1,9 +1,8 @@
-import { join } from 'path'
 import { loadSyncs } from './load'
 import { saveSyncs } from './save'
 
-// Use import.meta.dir to resolve relative to this package, not cwd
-export const syncsDir = join(import.meta.dir, '../../data/syncs/')
+// Re-export syncsDir from centralized paths utility
+export { syncsDir } from '../utils/paths'
 
 export const syncs = {
     load: loadSyncs,

--- a/packages/cli/src/tokens/index.ts
+++ b/packages/cli/src/tokens/index.ts
@@ -1,11 +1,10 @@
-import { join } from 'path'
 import { decryptTokens } from './decrypt'
 import { encryptTokens } from './encrypt'
 import { loadTokens } from './load'
 import { saveTokens } from './save'
 
-// Use import.meta.dir to resolve relative to this package, not cwd
-export const tokenFilePath = join(import.meta.dir, '../../data/tokens.json')
+// Re-export tokenFilePath from centralized paths utility
+export { tokenFilePath } from '../utils/paths'
 
 export const tokens = {
     load: loadTokens,

--- a/packages/cli/src/utils/paths.ts
+++ b/packages/cli/src/utils/paths.ts
@@ -1,0 +1,69 @@
+import { join } from 'path'
+import { homedir } from 'os'
+import { mkdirSync, existsSync } from 'fs'
+
+/**
+ * Get the appropriate data directory for tinysync based on the platform.
+ *
+ * - macOS: ~/.tinysync/
+ * - Linux: ~/.tinysync/ (or $XDG_DATA_HOME/tinysync if set)
+ * - Windows: %APPDATA%\tinysync\
+ *
+ * This ensures user data persists correctly regardless of how the CLI is installed
+ * (npm global, bun global, compiled binary, etc.)
+ */
+function getDataDir(): string {
+    const platform = process.platform
+
+    let baseDir: string
+
+    if (platform === 'win32') {
+        // Windows: Use APPDATA
+        baseDir = process.env.APPDATA || join(homedir(), 'AppData', 'Roaming')
+    } else if (platform === 'darwin') {
+        // macOS: Use ~/.tinysync for simplicity (could also use ~/Library/Application Support)
+        baseDir = homedir()
+    } else {
+        // Linux/other: Respect XDG_DATA_HOME or fall back to home
+        baseDir = process.env.XDG_DATA_HOME || homedir()
+    }
+
+    // Use .tinysync for Unix-like, tinysync for Windows (no dot)
+    const folderName = platform === 'win32' ? 'tinysync' : '.tinysync'
+
+    return join(baseDir, folderName)
+}
+
+/**
+ * The root data directory for tinysync user data.
+ */
+export const dataDir = getDataDir()
+
+/**
+ * Path to the tokens.json file.
+ */
+export const tokenFilePath = join(dataDir, 'tokens.json')
+
+/**
+ * Path to the syncs directory.
+ */
+export const syncsDir = join(dataDir, 'syncs/')
+
+/**
+ * Path to the logs directory.
+ */
+export const logsDir = join(dataDir, 'logs/')
+
+/**
+ * Ensures all required data directories exist.
+ * Call this at startup before any file operations.
+ */
+export function ensureDataDirs(): void {
+    const dirs = [dataDir, syncsDir, logsDir]
+
+    for (const dir of dirs) {
+        if (!existsSync(dir)) {
+            mkdirSync(dir, { recursive: true })
+        }
+    }
+}


### PR DESCRIPTION
Introduces a new utils/paths.ts module to centralize logic for determining and creating data directories (tokens, syncs, logs) in a cross-platform way. Updates all references to data/logs/syncs paths to use the new utility, ensures directories are created at startup, and updates build and package scripts to output to and use the dist directory. This improves portability and reliability of file operations across different environments.